### PR TITLE
Added basic RTTI, bugfixes

### DIFF
--- a/src/ast/lexer.rs
+++ b/src/ast/lexer.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 
 #[derive(Eq, PartialEq, Hash, Debug, Copy, Clone)]
-pub struct TokenSpanIndex(pub usize);
+pub struct TokenSpanIndex { pub index: usize, pub file: FileTableIndex }
 
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub struct TokenData {
@@ -19,7 +19,6 @@ pub struct SourceLocation {
 
 #[derive(Eq, PartialEq, Hash, Debug, Copy, Clone)]
 pub struct TokenSpan {
-    pub file: FileTableIndex,
     pub start: SourceLocation,
     pub end: SourceLocation,
 }
@@ -45,9 +44,9 @@ impl TokenTable {
         end: SourceLocation,
     ) {
         let cur_len = self.spans.len();
-        self.spans.push(TokenSpan { file, start, end });
+        self.spans.push(TokenSpan {  start, end });
         self.tokens.push(TokenData {
-            span_index: TokenSpanIndex(cur_len),
+            span_index: TokenSpanIndex { index: cur_len, file },
             token,
         });
     }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -53,13 +53,12 @@ impl StringInterner {
         interned
     }
 
-    #[cfg(test)]
     pub fn borrow(&'static self, string: InternedString) -> &'static str {
         let strings = self.state.lock().unwrap();
         let string = strings.strings.get(string.index).unwrap();
         unsafe {
-            //SAFETY: Should be OK 👀
-            std::mem::transmute::<&str, &str>(string)
+            //SAFETY: it's OK because we know that the string is never removed
+            std::mem::transmute::<&str, &'static str>(string)
         }
     }
 
@@ -116,6 +115,18 @@ impl InternedString {
 
     pub fn write_str(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         StringInterner::get().write_to(f, *self)
+    }
+}
+
+impl PartialEq<str> for InternedString {
+    fn eq(&self, other: &str) -> bool {
+        StringInterner::get().borrow(*self) == other
+    }
+}
+
+impl AsRef<str> for InternedString {
+    fn as_ref(&self) -> &str {
+        StringInterner::get().borrow(*self)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,6 @@ fn main() {
             }
         }
     }
-
-    generate_llvm(&ctx.type_db, &ctx.mir).unwrap();
+    ctx.ensure_instantiate_builtin_type("TypeData");
+    generate_llvm(&mut ctx.type_db, &ctx.mir).unwrap();
 }

--- a/src/semantic/hir_type_resolution.rs
+++ b/src/semantic/hir_type_resolution.rs
@@ -38,8 +38,7 @@ pub fn hir_type_to_usage(
     type_db: &TypeInstanceManager,
     type_parameters: &[TypeParameter],
     errors: &mut TypeErrors,
-    location: &impl Spanned,
-    file: FileTableIndex,
+    location: &impl Spanned
 ) -> Result<TypeConstructParams, CompilerError> {
     match typedef {
         HIRType::Simple(name) => {
@@ -59,7 +58,7 @@ pub fn hir_type_to_usage(
                     TypeNotFound {
                         type_name: HIRType::Simple(*name),
                     }
-                    .at_spanned(on_code_element, file, location, loc!()),
+                    .at_spanned(on_code_element, location, loc!()),
                 )
                 .as_type_inference_error();
         }
@@ -73,8 +72,7 @@ pub fn hir_type_to_usage(
                         type_db,
                         type_parameters,
                         errors,
-                        location,
-                        file,
+                        location
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -86,7 +84,6 @@ pub fn hir_type_to_usage(
                 type_parameters,
                 errors,
                 location,
-                file,
             )?;
 
             Ok(TypeConstructParams::FunctionSignature(FunctionSignature {
@@ -106,7 +103,6 @@ pub fn hir_type_to_usage(
                 type_parameters,
                 errors,
                 location,
-                file,
             );
         }
         HIRType::Generic(base, args) => {
@@ -121,7 +117,6 @@ pub fn hir_type_to_usage(
                         type_parameters,
                         errors,
                         location,
-                        file,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -147,7 +142,7 @@ pub fn hir_type_to_usage(
                     TypeNotFound {
                         type_name: HIRType::Simple(*base),
                     }
-                    .at_spanned(on_code_element, file, location, loc!()),
+                    .at_spanned(on_code_element, location, loc!()),
                 )
                 .as_type_inference_error()
         }

--- a/src/semantic/mir_printer.rs
+++ b/src/semantic/mir_printer.rs
@@ -65,6 +65,9 @@ impl<'type_db> MIRPrinter<'type_db> {
             MIRExpr::RValue(MIRExprRValue::Cast(expr, ty, ..)) => {
                 format!("{expr} as {ty}", expr = self.print(expr), ty = ty.to_string(self.type_db))
             }
+            MIRExpr::RValue(MIRExprRValue::TypeVariable { type_variable, .. }) => {
+                format!("{}", type_variable.to_string(self.type_db))
+            }
         }
     }
 

--- a/src/types/diagnostics.rs
+++ b/src/types/diagnostics.rs
@@ -41,7 +41,6 @@ where
 {
     pub error: T,
     pub on_element: RootElementType,
-    pub file: FileTableIndex,
     pub location: TokenSpanIndex,
     pub compiler_code_location: &'static str,
 }
@@ -52,7 +51,6 @@ pub trait ContextualizedCompilerError<T: CompilerErrorData> {
     fn at(
         self,
         on_element: RootElementType,
-        file: FileTableIndex,
         location: TokenSpanIndex,
         compiler_code_location: &'static str,
     ) -> CompilerErrorContext<T>;
@@ -60,7 +58,6 @@ pub trait ContextualizedCompilerError<T: CompilerErrorData> {
     fn at_spanned(
         self,
         on_element: RootElementType,
-        file: FileTableIndex,
         span: &impl Spanned,
         compiler_code_location: &'static str,
     ) -> CompilerErrorContext<T>;
@@ -70,14 +67,12 @@ impl<T: Sized + CompilerErrorData> ContextualizedCompilerError<T> for T {
     fn at(
         self,
         on_element: RootElementType,
-        file: FileTableIndex,
         location: TokenSpanIndex,
         compiler_code_location: &'static str,
     ) -> CompilerErrorContext<T> {
         CompilerErrorContext {
             error: self,
             on_element,
-            file,
             location,
             compiler_code_location,
         }
@@ -86,12 +81,11 @@ impl<T: Sized + CompilerErrorData> ContextualizedCompilerError<T> for T {
     fn at_spanned(
         self,
         on_element: RootElementType,
-        file: FileTableIndex,
         span: &impl Spanned,
         compiler_code_location: &'static str,
     ) -> CompilerErrorContext<T> {
         let span = span.get_span();
-        self.at(on_element, file, span.start, compiler_code_location)
+        self.at(on_element, span.start, compiler_code_location)
     }
 }
 
@@ -843,10 +837,10 @@ macro_rules! make_type_errors {
                 }
                 $(
                     for err in self.errors.$field.errors.iter() {
-                        let file = &self.file_table[err.file.0];
+                        let file = &self.file_table[err.location.file.0];
                         let file_name = &file.path;
-                        let tok = file.token_table.tokens[err.location.0];
-                        let span = file.token_table.spans[tok.span_index.0];
+                        let tok = file.token_table.tokens[err.location.index];
+                        let span = file.token_table.spans[tok.span_index.index];
                         let line = span.start.line;
                         let column = span.start.column;
                         write!(f, "{file_name}:{line}:{column}: ")?;

--- a/src/types/type_constructor_db.rs
+++ b/src/types/type_constructor_db.rs
@@ -514,7 +514,7 @@ impl TypeConstructorDatabase {
             TypeConstructorFunctionDeclaration {
                 name: istr("write"),
                 args: vec![
-                    TypeConstructParams::Given(u32_type), /* offset * sizeof(TPtr)*/
+                    TypeConstructParams::Given(self.common_types.u64), /* offset * sizeof(TPtr)*/
                     TypeConstructParams::Generic(TypeParameter(istr("TPtr"))),
                 ],
                 return_type: TypeConstructParams::Given(void_type),
@@ -525,8 +525,20 @@ impl TypeConstructorDatabase {
             ptr_type,
             TypeConstructorFunctionDeclaration {
                 name: istr("read"),
-                args: vec![TypeConstructParams::Given(u32_type)],/* offset * sizeof(TPtr) */
+                args: vec![TypeConstructParams::Given(self.common_types.u64)],/* offset * sizeof(TPtr) */
                 return_type: TypeConstructParams::Generic(TypeParameter(istr("TPtr"))),
+                is_variadic: false,
+            },
+        );
+        self.add_method(
+            ptr_type,
+            TypeConstructorFunctionDeclaration {
+                name: istr("__index_ptr__"),
+                args: vec![TypeConstructParams::Given(self.common_types.u64)],/* offset * sizeof(TPtr) */
+                return_type: TypeConstructParams::Parameterized(
+                    TypeConstructParams::Given(ptr_type).into(),
+                    vec![TypeConstructParams::Generic(TypeParameter(istr("TPtr")))],
+                ),
                 is_variadic: false,
             },
         );
@@ -570,6 +582,8 @@ impl TypeConstructorDatabase {
         //self cast is ok... silly but ok
         self.add_cast_to_type(self.common_types.i32, self.common_types.i32);
         self.add_cast_to_type(self.common_types.i32, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.i32, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.i32, self.common_types.u64);
         self.add_cast_to_type(self.common_types.i32, self.common_types.f32);
         self.add_cast_to_type(self.common_types.i32, self.common_types.f64);
         self.add_cast_to_type(self.common_types.i32, self.common_types.char);
@@ -577,6 +591,8 @@ impl TypeConstructorDatabase {
 
         self.add_cast_to_type(self.common_types.i64, self.common_types.i32);
         self.add_cast_to_type(self.common_types.i64, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.i64, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.i64, self.common_types.u64);
         self.add_cast_to_type(self.common_types.i64, self.common_types.f32);
         self.add_cast_to_type(self.common_types.i64, self.common_types.f64);
         self.add_cast_to_type(self.common_types.i64, self.common_types.char);
@@ -584,6 +600,8 @@ impl TypeConstructorDatabase {
 
         self.add_cast_to_type(self.common_types.f32, self.common_types.i32);
         self.add_cast_to_type(self.common_types.f32, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.f32, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.f32, self.common_types.u64);
         self.add_cast_to_type(self.common_types.f32, self.common_types.f32);
         self.add_cast_to_type(self.common_types.f32, self.common_types.f64);
         self.add_cast_to_type(self.common_types.f32, self.common_types.char);
@@ -591,6 +609,8 @@ impl TypeConstructorDatabase {
 
         self.add_cast_to_type(self.common_types.f64, self.common_types.i32);
         self.add_cast_to_type(self.common_types.f64, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.f64, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.f64, self.common_types.u64);
         self.add_cast_to_type(self.common_types.f64, self.common_types.f32);
         self.add_cast_to_type(self.common_types.f64, self.common_types.f64);
         self.add_cast_to_type(self.common_types.f64, self.common_types.char);
@@ -598,6 +618,8 @@ impl TypeConstructorDatabase {
 
         self.add_cast_to_type(self.common_types.char, self.common_types.i32);
         self.add_cast_to_type(self.common_types.char, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.char, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.char, self.common_types.u64);
         self.add_cast_to_type(self.common_types.char, self.common_types.f32);
         self.add_cast_to_type(self.common_types.char, self.common_types.f64);
         self.add_cast_to_type(self.common_types.char, self.common_types.char);
@@ -605,10 +627,30 @@ impl TypeConstructorDatabase {
 
         self.add_cast_to_type(self.common_types.u8, self.common_types.i32);
         self.add_cast_to_type(self.common_types.u8, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.u8, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.u8, self.common_types.u64);
         self.add_cast_to_type(self.common_types.u8, self.common_types.f32);
         self.add_cast_to_type(self.common_types.u8, self.common_types.f64);
         self.add_cast_to_type(self.common_types.u8, self.common_types.char);
         self.add_cast_to_type(self.common_types.u8, self.common_types.u8);
+
+        self.add_cast_to_type(self.common_types.u32, self.common_types.i32);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.u64);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.f32);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.f64);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.char);
+        self.add_cast_to_type(self.common_types.u32, self.common_types.u8);
+
+        self.add_cast_to_type(self.common_types.u64, self.common_types.i32);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.i64);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.u32);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.u64);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.f32);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.f64);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.char);
+        self.add_cast_to_type(self.common_types.u64, self.common_types.u8);
     }
         
 }

--- a/src/types/type_instance_db.rs
+++ b/src/types/type_instance_db.rs
@@ -333,11 +333,17 @@ impl TypeInstanceManager {
                 }
             }
             TypeConstructParams::FunctionSignature(FunctionSignature {
-                generics: _,
+                generics,
                 params,
                 return_type,
                 variadic,
             }) => {
+
+                if generics.len() > 0 && type_args.len() == 0 {
+                    log!("Insufficient information because it's generic");
+                    return Err(TypeConstructionError::InsufficientInformation);
+                }
+
                 let params_constructed = params
                     .iter()
                     .map(|x| {

--- a/stdlib/asserts.dk
+++ b/stdlib/asserts.dk
@@ -1,5 +1,7 @@
 def panic(message: str):
-    print(message)
+    printf("PANIC: ".buf)
+    printf(message.buf)
+    printf("\n".buf)
     exit(1)
 
 def assert_i32_equals(a: i32, b: i32):
@@ -7,3 +9,8 @@ def assert_i32_equals(a: i32, b: i32):
         printf("assertion failed: %d != %d\n".buf, a, b)
         exit(1)
 
+
+def assert_eq<T>(a: T, b: T):
+    if a != b:
+        printf("assertion failed: %d != %d\n".buf, a, b)
+        exit(1)

--- a/stdlib/c_lib.dk
+++ b/stdlib/c_lib.dk
@@ -19,7 +19,7 @@ def sqrtf(val: f32) -> f32:
 def exit(code: i32):
     external
 
-def malloc(size: u32) -> ptr<u8>:
+def malloc(size: u64) -> ptr<u8>:
     external
     
 def free(buf: ptr<u8>):

--- a/stdlib/list.dk
+++ b/stdlib/list.dk
@@ -1,7 +1,7 @@
 struct List<T>:
     buf: ptr<T>
-    len: u32
-    cap: u32
+    len: u64
+    cap: u64
 
 def list_new<T>() -> List<T>:
     list = List<T>()
@@ -18,18 +18,31 @@ def list_add<T>(list: ptr<List<T>>, item: T):
             (*list).cap = 4
         else:
             (*list).cap = cap * 2
-        
-    ptr_as_u8 = reinterpret_ptr<T, u8>((*list).buf)
-    ptr_reallocated = malloc(cap * (4 as u64))
-    (*list).buf = reinterpret_ptr<u8, T>(ptr_reallocated)
 
-    (*list).buf.write(len, item)
+        new_allocation = mem_alloc<T>((*list).cap)
+        if len > 0:
+            i: u64 = 0
+            while i < len:
+                new_allocation[i] = (*list).buf[i]
+                i = i + 1
+            mem_free<T>((*list).buf)
+
+        (*list).buf = new_allocation   
+    
+    (*list).buf[len] = item
     (*list).len = len + 1
 
-
-def reinterpret_ptr<T, U>(p: ptr<T>) -> ptr<U>:
-    intrinsic
+def list_get<T>(list: ptr<List<T>>, index: u64) -> T:
+    return (*list).buf[index]
 
 def main():
     new_list = list_new<i32>()
-    list_add<i32>(&new_list, 1)
+    items = 0
+    while items <= 10:
+        list_add<i32>(&new_list, items)
+        items = items + 1
+
+    i: u64 = 0
+    while i < new_list.len:
+        print_int(list_get<i32>(&new_list, i))
+        i = i + 1

--- a/stdlib/llvm_intrinsics.dk
+++ b/stdlib/llvm_intrinsics.dk
@@ -22,3 +22,21 @@ def print_f32(f: f32):
 
 def print_f64(f: f64):
     printf("%d\n".buf, f)
+
+def reinterpret_ptr<T, U>(p: ptr<T>) -> ptr<U>:
+    intrinsic
+
+def mem_alloc<T>(elems: u64) -> ptr<T>:
+    num_bytes = elems * T.size
+    printf("mem_alloc: Allocating %d bytes\n".buf, num_bytes)
+    new_allocation = malloc(elems * T.size)
+    return reinterpret_ptr<u8, T>(new_allocation)
+
+def mem_free<T>(p: ptr<T>):
+    as_u8 = reinterpret_ptr<T, u8>(p)
+    printf("mem_free: Freeing ptr...\n".buf)
+    free(as_u8)
+
+struct TypeData:
+    name: str
+    size: u64


### PR DESCRIPTION
Basic RTTI
========

When you mention a type name in code, it acts as a variable of type TypeData with 2 properties: name and size (in bytes).

For instance:

```
x = i32.size
```

In this case, x is 4, and `i32` is a special type called `TypeData`.

This works in generics too.

One could imagine a function like this:

```
def mem_alloc(type: TypeData, elements: u64) -> ptr<u8>:
    return malloc(type.size * elements)
```

This is alright, but you can also do:

```
def mem_alloc<T>(elements: u64) -> ptr<T>:
    p: ptr<u8> = malloc(T.size * elements)
    return reinterpret_ptr<u8, T>(p)
```

`reinterpret_ptr` is a compiler intrinsic function.

How it works?
===========

It's actually very simple. For each TypeData that is referenced in code, the compiler emits some global data that is present in the final binary.

If we were emitting C code, Imagine that our code would look something like this:

```
typedef struct TypeData {int size; /*other properties/*}

static struct TypeData TypeData_i32 = { .size: 4, ...};
```

When you want to get `i32.size`, we access `TypeData_i32.size`.

In LLVM, this explaination is surprisingly close to the C one, but just look at the code to understand.